### PR TITLE
Support for pre-existing version numbers having a 'v' prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ These tools are designed to facilate version calculation and respository tagging
 
 There are two scripts: one for semver calculation and another which tags your Git repository according to the calculated version script. Git is only required if and when you want to tag your repository using the tagging script.
 
+Pre-existing tags must be of one of the following forms to be recognized by this tool:
+
+- (major).(minor).(patch)
+	- Example: `1.2.3`
+- v(major).(minor).(patch)
+	- Example: `v1.2.3`
+
+Tags created by this tool will match the form of the most recent pre-existing tag.
+
 Here's example of how to calculate the next semver value based upon the existing version:
 
 ```
@@ -13,23 +22,23 @@ usage: usage: bumpit [-Mmp] major.minor.patch [-d|--dirty]
 $ bumpit -p 0.0.0
 0.0.1
 
-$ bumpit -m 0.0.3
-0.1.0
+$ bumpit -m v0.0.3
+v0.1.0
 
 $ bumpit -M 1.1.15
 2.0.0
 
-$ bumpit -Mmp 2.3.4
-3.1.1
+$ bumpit -Mmp v2.3.4
+v3.1.1
 
 $ bumpit -p 1.2.3-17-6fb3af9 # (results of git-describe)
 1.2.4
 
-$ bumpit -p 1.2.3-17-6fb3af9 --dirty
-1.2.4
+$ bumpit -p v1.2.3-17-6fb3af9 --dirty
+v1.2.4
 
-$ bumpit -p 1.2.3 --dirty # version is clean, it doesn't increment
-1.2.3
+$ bumpit -p v1.2.3 --dirty # version is clean, it doesn't increment
+v1.2.3
 ```
 
 Here's an example of how to tag your Git repository based upon the existing semver-based tags:

--- a/src/bumpit
+++ b/src/bumpit
@@ -1,34 +1,70 @@
 #!/usr/bin/env sh
 set -e
 
-if test "x${1}" = "x" || test "x${2}" = "x"; then
-   echo "usage: $(basename ${0}) [-Mmp] major.minor.patch [-d|--dirty]" && exit 1
-fi
-
-while getopts ":Mmp" bump; do
-  case $bump in
-    M) bump_major=true;;
-    m) bump_minor=true;;
-    p) bump_patch=true;;
+# Transform long options to short ones:
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--dirty") set -- "$@" "-d" ;;
+    *)         set -- "$@" "$arg"
   esac
 done
 
-vgone=$(echo "${2}" | sed 's/^v//')
+option_count=0
+
+# Parse positional options:
+while getopts "Mmpd" bump; do
+  case ${bump} in
+    d) bump_dirty=true;;
+    p) bump_patch=true; option_count=$((option_count+1));;
+    m) bump_minor=true; option_count=$((option_count+1));;
+    M) bump_major=true; option_count=$((option_count+1));;
+  esac
+done
+
+# Only one incrementation option is allowed:
+if [ "$option_count" -ne "1" ]; then
+  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+fi
+
+# Remove all args except final, non-positional arg (the version number):
+shift "$((OPTIND-1))"
+
+# Parse the given version:
+first=${1}
+vgone=$(echo "${first}" | sed 's/^v//')
 clean=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[1]}')
 dirty=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[2]}')
 major=$(echo "${clean}" | awk '{split($0,a,"."); print a[1]}')
 minor=$(echo "${clean}" | awk '{split($0,a,"."); print a[2]}')
 patch=$(echo "${clean}" | awk '{split($0,a,"."); print a[3]}')
 
-# if the --dirty flag is specified, exit if we are in a clean state
-(test "x${3}" = "x--dirty" || test "x${3}" = "x-d" ) && test "x${dirty}" = "x" && echo "${clean}" && exit 0
+# Only numeric elements are allowed for major.minor.patch:
+numeric='^[0-9]+$'
+if ! [[ ${major} =~ $numeric ]]; then
+  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+elif ! [[ ${minor} =~ $numeric ]]; then
+  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+elif ! [[ ${patch} =~ $numeric ]]; then
+  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+fi
 
+# Add 'v' prefix back if it was supplied originally:
+if [[ ${first:0:1} == "v" ]]; then
+  clean=$(echo "v${clean}")
+fi
+
+# if the --dirty flag is specified, exit if we are in a clean state:
+[ ! -z ${bump_dirty} ] && test "x${dirty}" = "x" && echo "${clean}" && exit 0
+
+# Increment the version number:
 [ ! -z ${bump_major} ] && major=$((major+1)) && minor=0 && patch=0
 [ ! -z ${bump_minor} ] && minor=$((minor+1)) && patch=0
 [ ! -z ${bump_patch} ] && patch=$((patch+1))
 
-if [[ ${2} == v* ]]; then
-	echo "v${major}.${minor}.${patch}"
-else 
-	echo "${major}.${minor}.${patch}"
+# Render final version with 'v' if originally supplied:
+final=$(echo "${major}.${minor}.${patch}")
+if [[ ${first:0:1} == "v" ]]; then
+  final=$(echo "v${final}")
 fi
+echo "${final}"

--- a/src/bumpit
+++ b/src/bumpit
@@ -13,8 +13,9 @@ while getopts ":Mmp" bump; do
   esac
 done
 
-clean=$(echo "${2}" | awk '{split($0,a,"-"); print a[1]}')
-dirty=$(echo "${2}" | awk '{split($0,a,"-"); print a[2]}')
+vgone=$(echo "${2}" | sed 's/^v//')
+clean=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[1]}')
+dirty=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[2]}')
 major=$(echo "${clean}" | awk '{split($0,a,"."); print a[1]}')
 minor=$(echo "${clean}" | awk '{split($0,a,"."); print a[2]}')
 patch=$(echo "${clean}" | awk '{split($0,a,"."); print a[3]}')
@@ -26,4 +27,8 @@ patch=$(echo "${clean}" | awk '{split($0,a,"."); print a[3]}')
 [ ! -z ${bump_minor} ] && minor=$((minor+1)) && patch=0
 [ ! -z ${bump_patch} ] && patch=$((patch+1))
 
-echo "${major}.${minor}.${patch}"
+if [[ ${2} == v* ]]; then
+	echo "v${major}.${minor}.${patch}"
+else 
+	echo "${major}.${minor}.${patch}"
+fi

--- a/src/bumpit
+++ b/src/bumpit
@@ -22,9 +22,11 @@ while getopts "Mmpd" bump; do
   esac
 done
 
+usage_text="usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch"
+
 # Only one incrementation option is allowed:
 if [ "$option_count" -ne "1" ]; then
-  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+  echo "${usage_text}" && exit 1
 fi
 
 # Remove all args except final, non-positional arg (the version number):
@@ -40,12 +42,12 @@ minor=$(echo "${clean}" | awk '{split($0,a,"."); print a[2]}') # 1.2.3-17-6fb3af
 patch=$(echo "${clean}" | awk '{split($0,a,"."); print a[3]}') # 1.2.3-17-6fb3af9 -> 3
 
 # Each element must be populated:
-[ -z ${major} ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
-[ -z ${minor} ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
-[ -z ${patch} ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+[ -z ${major} ] && echo "${usage_text}" && exit 1
+[ -z ${minor} ] && echo "${usage_text}" && exit 1
+[ -z ${patch} ] && echo "${usage_text}" && exit 1
 
 # Each element must contain digits only:
-[ `echo "${clean}" | sed 's/[0-9]//g'` != ".." ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+[ `echo "${clean}" | sed 's/[0-9]//g'` != ".." ] && echo "${usage_text}" && exit 1
 
 # Add 'v' prefix back if it was supplied originally:
 case "$first" in

--- a/src/bumpit
+++ b/src/bumpit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+
 set -e
 
 # Transform long options to short ones:
@@ -10,9 +11,8 @@ for arg in "$@"; do
   esac
 done
 
-option_count=0
-
 # Parse positional options:
+option_count=0
 while getopts "Mmpd" bump; do
   case ${bump} in
     d) bump_dirty=true;;
@@ -33,28 +33,27 @@ shift "$((OPTIND-1))"
 # Parse the given version:
 first=${1}
 vgone=$(echo "${first}" | sed 's/^v//')
-clean=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[1]}')
-dirty=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[2]}')
-major=$(echo "${clean}" | awk '{split($0,a,"."); print a[1]}')
-minor=$(echo "${clean}" | awk '{split($0,a,"."); print a[2]}')
-patch=$(echo "${clean}" | awk '{split($0,a,"."); print a[3]}')
+clean=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[1]}') # 1.2.3-17-6fb3af9 -> 1.2.3
+dirty=$(echo "${vgone}" | awk '{split($0,a,"-"); print a[2]}') # 1.2.3-17-6fb3af9 -> -17-6fb3af9
+major=$(echo "${clean}" | awk '{split($0,a,"."); print a[1]}') # 1.2.3-17-6fb3af9 -> 1
+minor=$(echo "${clean}" | awk '{split($0,a,"."); print a[2]}') # 1.2.3-17-6fb3af9 -> 2
+patch=$(echo "${clean}" | awk '{split($0,a,"."); print a[3]}') # 1.2.3-17-6fb3af9 -> 3
 
-# Only numeric elements are allowed for major.minor.patch:
-numeric='^[0-9]+$'
-if ! [[ ${major} =~ $numeric ]]; then
-  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
-elif ! [[ ${minor} =~ $numeric ]]; then
-  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
-elif ! [[ ${patch} =~ $numeric ]]; then
-  echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
-fi
+# Each element must be populated:
+[ -z ${major} ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+[ -z ${minor} ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+[ -z ${patch} ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
+
+# Each element must contain digits only:
+[ `echo "${clean}" | sed 's/[0-9]//g'` != ".." ] && echo "usage: $(basename ${0}) [-Mmp -d|--dirty] major.minor.patch" && exit 1
 
 # Add 'v' prefix back if it was supplied originally:
-if [[ ${first:0:1} == "v" ]]; then
-  clean=$(echo "v${clean}")
-fi
+case "$first" in
+  v*) clean=$(echo "v${clean}");;
+  *);;
+esac
 
-# if the --dirty flag is specified, exit if we are in a clean state:
+# Leave version unchanged if --dirty and version is 'clean':
 [ ! -z ${bump_dirty} ] && test "x${dirty}" = "x" && echo "${clean}" && exit 0
 
 # Increment the version number:
@@ -64,7 +63,9 @@ fi
 
 # Render final version with 'v' if originally supplied:
 final=$(echo "${major}.${minor}.${patch}")
-if [[ ${first:0:1} == "v" ]]; then
-  final=$(echo "v${final}")
-fi
+case "$first" in
+  v*) final=$(echo "v${final}");;
+  *);;
+esac
+
 echo "${final}"

--- a/src/bumpit_test
+++ b/src/bumpit_test
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+
+assert() {
+  # See https://github.com/torokmark/assert.sh
+
+  local input=$1
+  local actual=`$1`
+  local expected="$2"
+
+  if [ "$expected" == "$actual" ]; then
+    printf "✔ $input --> [$actual]\n" "$@" >&2 || true
+    return 0
+  else
+    printf "✖ $input --> [$actual] should equal [$expected]\n" "$@" >&2 || true
+    return 1
+  fi
+}
+
+describe() {
+  printf "\n==== $1 ====\n\n"
+}
+
+# assert "command" "expected output"
+
+describe "Missing version entirely? Display the usage message."
+assert "./bumpit -p " "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # missing version entirely
+assert "./bumpit -m " "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # missing version entirely
+assert "./bumpit -M " "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # missing version entirely
+
+describe "Non-numeric element? Display the usage message."
+assert "./bumpit -p 1.2.a" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # non-numeric element
+assert "./bumpit -m 1.2.a" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # non-numeric element
+assert "./bumpit -M 1.2.a" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # non-numeric element
+
+describe "Totally invalid version? Display the usage message."
+assert "./bumpit -p not-a-version" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # totally invalid
+assert "./bumpit -m not-a-version" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # totally invalid
+assert "./bumpit -M not-a-version" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # totally invalid
+
+describe "Ambiguous options? Display the usage message."
+assert "./bumpit -p -m -M 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
+assert "./bumpit -m -M -p 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
+assert "./bumpit -M -p -m 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
+assert "./bumpit -p -m 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
+assert "./bumpit -M -m 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
+assert "./bumpit -M -p 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
+
+describe "Basic use case."
+assert "./bumpit -p 0.0.0" "0.0.1"
+assert "./bumpit -m 0.0.0" "0.1.0"
+assert "./bumpit -M 0.0.0" "1.0.0"
+assert "./bumpit -p 1.1.1" "1.1.2"
+assert "./bumpit -m 1.1.1" "1.2.0"
+assert "./bumpit -M 1.1.1" "2.0.0"
+
+describe "Basic use case with a 'v' prefix."
+assert "./bumpit -p v0.0.0" "v0.0.1"
+assert "./bumpit -m v0.0.0" "v0.1.0"
+assert "./bumpit -M v0.0.0" "v1.0.0"
+assert "./bumpit -p v1.1.1" "v1.1.2"
+assert "./bumpit -m v1.1.1" "v1.2.0"
+assert "./bumpit -M v1.1.1" "v2.0.0"
+
+describe "When passing -d, don't update 'clean' versions."
+assert "./bumpit -p -d 0.0.0" "0.0.0"
+assert "./bumpit -m -d 0.1.0" "0.1.0"
+assert "./bumpit -M -d 1.0.0" "1.0.0"
+
+describe "When passing -d, don't update 'clean' versions with a 'v' prefix."
+assert "./bumpit -p -d v0.0.0" "v0.0.0"
+assert "./bumpit -m -d v0.1.0" "v0.1.0"
+assert "./bumpit -M -d v1.0.0" "v1.0.0"
+
+describe "When passing -d, update 'dirty' versions."
+assert "./bumpit -p -d 0.0.0-17-6fb3af9" "0.0.1"
+assert "./bumpit -m -d 0.0.0-17-6fb3af9" "0.1.0"
+assert "./bumpit -M -d 0.0.0-17-6fb3af9" "1.0.0"
+
+describe "When passing -d, update 'dirty' versions with a 'v' prefix."
+assert "./bumpit -p -d v0.0.0-17-6fb3af9" "v0.0.1"
+assert "./bumpit -m -d v0.0.0-17-6fb3af9" "v0.1.0"
+assert "./bumpit -M -d v0.0.0-17-6fb3af9" "v1.0.0"
+

--- a/src/bumpit_test
+++ b/src/bumpit_test
@@ -21,29 +21,30 @@ describe() {
 }
 
 # assert "command" "expected output"
+usage_text="usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
 
 describe "Missing version entirely? Display the usage message."
-assert "./bumpit -p" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" 1 # missing version entirely
-assert "./bumpit -m" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" 1 # missing version entirely
-assert "./bumpit -M" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" 1 # missing version entirely
+assert "./bumpit -p" "${usage_text}" 1 # missing version entirely
+assert "./bumpit -m" "${usage_text}" 1 # missing version entirely
+assert "./bumpit -M" "${usage_text}" 1 # missing version entirely
 
 describe "Non-numeric element? Display the usage message."
-assert "./bumpit -p 1.2.a" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # non-numeric element
-assert "./bumpit -m 1.2.a" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # non-numeric element
-assert "./bumpit -M 1.2.a" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # non-numeric element
+assert "./bumpit -p 1.2.a" "${usage_text}" # non-numeric element
+assert "./bumpit -m 1.2.a" "${usage_text}" # non-numeric element
+assert "./bumpit -M 1.2.a" "${usage_text}" # non-numeric element
 
 describe "Totally invalid version? Display the usage message."
-assert "./bumpit -p not-a-version" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # totally invalid
-assert "./bumpit -m not-a-version" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # totally invalid
-assert "./bumpit -M not-a-version" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # totally invalid
+assert "./bumpit -p not-a-version" "${usage_text}" # totally invalid
+assert "./bumpit -m not-a-version" "${usage_text}" # totally invalid
+assert "./bumpit -M not-a-version" "${usage_text}" # totally invalid
 
 describe "Ambiguous options? Display the usage message."
-assert "./bumpit -p -m -M 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
-assert "./bumpit -m -M -p 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
-assert "./bumpit -M -p -m 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
-assert "./bumpit -p -m 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
-assert "./bumpit -M -m 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
-assert "./bumpit -M -p 0.0.0" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch"
+assert "./bumpit -p -m -M 0.0.0" "${usage_text}"
+assert "./bumpit -m -M -p 0.0.0" "${usage_text}"
+assert "./bumpit -M -p -m 0.0.0" "${usage_text}"
+assert "./bumpit -p -m 0.0.0" "${usage_text}"
+assert "./bumpit -M -m 0.0.0" "${usage_text}"
+assert "./bumpit -M -p 0.0.0" "${usage_text}"
 
 describe "Basic use case."
 assert "./bumpit -p 0.0.0" "0.0.1"

--- a/src/bumpit_test
+++ b/src/bumpit_test
@@ -3,16 +3,16 @@
 assert() {
   # See https://github.com/torokmark/assert.sh
 
-  local input=$1
-  local actual=`$1`
+  local input="$1"
+  local actual="$($1)"
   local expected="$2"
 
-  if [ "$expected" == "$actual" ]; then
-    printf "✔ $input --> [$actual]\n" "$@" >&2 || true
-    return 0
-  else
+  if [ "$expected" != "$actual" ]; then
     printf "✖ $input --> [$actual] should equal [$expected]\n" "$@" >&2 || true
     return 1
+  else
+    printf "✔ $input --> [$actual]\n" "$@" >&2 || true
+    return 0
   fi
 }
 
@@ -23,9 +23,9 @@ describe() {
 # assert "command" "expected output"
 
 describe "Missing version entirely? Display the usage message."
-assert "./bumpit -p " "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # missing version entirely
-assert "./bumpit -m " "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # missing version entirely
-assert "./bumpit -M " "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # missing version entirely
+assert "./bumpit -p" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" 1 # missing version entirely
+assert "./bumpit -m" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" 1 # missing version entirely
+assert "./bumpit -M" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" 1 # missing version entirely
 
 describe "Non-numeric element? Display the usage message."
 assert "./bumpit -p 1.2.a" "usage: bumpit [-Mmp -d|--dirty] major.minor.patch" # non-numeric element

--- a/src/tagit
+++ b/src/tagit
@@ -19,7 +19,7 @@ git rev-parse --git-dir >/dev/null 2>/dev/null || (echo "${message}" && exit 3)
 version="$(git describe --tags 2>/dev/null || echo "0.0.0")"
 bump="$(dirname "${0}")/bumpit"
 clean="$("${bump}" -${1} "${version}")"
-dirty="$("${bump}" -${1} "${version}" --dirty)"
+dirty="$("${bump}" -${1} --dirty "${version}")"
 
 message="${dirty}"
 test "x${dryrun}" = "xtrue" && echo "${dirty}" && exit 0


### PR DESCRIPTION
The main motivation for this change is so that this tool will support
playing nicely with go modules:

https://github.com/golang/go/wiki/Modules#modules

> "...The leading v is required."